### PR TITLE
ha: AiFw HA epic integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,51 @@ Client → UDP/TCP/TLS Listener → Query Router
 - Zone data held in memory, loaded from files or PostgreSQL
 - PostgreSQL LISTEN/NOTIFY for real-time zone reload
 
+## AiFw HA Integration
+
+When AiFw is deployed in active-passive cluster mode, a CARP virtual IP floats between
+nodes. LAN clients that use the AiFw box as their DNS resolver should point at the CARP
+VIP rather than a physical interface IP so that DNS resolution continues transparently
+after failover.
+
+### Bind to wildcard (recommended)
+
+rDNS's default config already uses wildcard addresses:
+
+```toml
+[listeners]
+udp = ["0.0.0.0:53", "[::]:53"]
+tcp = ["0.0.0.0:53", "[::]:53"]
+```
+
+With this configuration, rDNS on the new CARP master accepts queries arriving at the
+VIP immediately after failover — no rDNS configuration change is required.
+
+**Verify your deployment uses wildcard listeners.** If your config specifies a
+physical interface IP (e.g. `udp = ["192.168.1.1:53"]`), rDNS on the new master
+will not respond to queries directed at the CARP VIP until you update the listen
+address and reload.
+
+### Multi-address listen (if IP-specific binding is required)
+
+If you need rDNS bound to a specific interface IP and also the CARP VIP, list both:
+
+```toml
+[listeners]
+udp = ["192.168.1.1:53", "192.168.1.254:53"]   # physical + CARP VIP
+tcp = ["192.168.1.1:53", "192.168.1.254:53"]
+```
+
+rDNS iterates the list and spawns one listener task per address, so both are served
+simultaneously.
+
+### Failover behavior
+
+On CARP failover the new master's rDNS process is already running with the CARP VIP
+in its listener list (or on `0.0.0.0`). Because rDNS's cache is local to each node,
+clients may see a brief increase in resolver latency on the first query after failover
+(cache miss to upstream), then resume normal cached performance.
+
 ## License
 
 MIT


### PR DESCRIPTION
## Summary

Companion-repo work for AiFw's HA epic (AiFw#224). When AiFw is
configured as an active-passive CARP cluster, rDNS must remain
reachable on the CARP VIP after failover so LAN clients using the
VIP as their DNS resolver do not lose service.

- Adds "AiFw HA Integration" section to README confirming that
  rDNS's default wildcard listeners (`0.0.0.0:53` / `[::]:53`) already
  accept queries arriving at the CARP VIP on the new master — no
  code or config change required for standard deployments
- Documents the multi-address listen syntax for operators who need
  IP-specific bindings alongside the CARP VIP
- Notes post-failover cache-miss behavior so operators set expectations

## Test plan

- [ ] Confirm `rdns.toml` uses `udp = ["0.0.0.0:53", "[::]:53"]` (default)
- [ ] On a two-node AiFw cluster, trigger CARP failover
- [ ] Verify DNS queries to the CARP VIP are answered by rDNS on the new master
- [ ] Verify DNS resolution resumes within one TTL cycle for cached records