### PR TITLE
fix(listener): demote benign accept() aborts from WARN to debug

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1135,7 +1135,7 @@ dependencies = [
 
 [[package]]
 name = "rdns"
-version = "1.17.2"
+version = "1.17.4"
 dependencies = [
  "anyhow",
  "arc-swap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rdns"
-version = "1.17.3"
+version = "1.17.4"
 edition = "2024"
 license = "MIT"
 description = "A high-performance, security-focused DNS server written in Rust"

--- a/src/listener/tcp.rs
+++ b/src/listener/tcp.rs
@@ -44,15 +44,21 @@ pub async fn serve(
     loop {
         let (stream, src) = match listener.accept().await {
             Ok(pair) => pair,
+            Err(e) if super::is_resource_exhaustion(&e) => {
+                tracing::warn!(%addr, error = %e, "TCP accept() failed: resource exhaustion (EMFILE/ENFILE); backing off");
+                tokio::time::sleep(Duration::from_millis(50)).await;
+                continue;
+            }
             Err(e) if super::is_transient_accept_error(&e) => {
-                tracing::warn!(%addr, error = %e, "Transient accept() error; continuing");
-                if super::is_resource_exhaustion(&e) {
-                    tokio::time::sleep(Duration::from_millis(50)).await;
-                }
+                // Peer aborted before accept(); kernel discards the queued
+                // sockaddr, so source IP is unrecoverable here. Use tcpdump
+                // on the listening interface if you need to identify the client.
+                tracing::debug!(%addr, error = %e, "TCP accept() aborted before peer address available (peer RST mid-handshake)");
                 continue;
             }
             Err(e) => return Err(e.into()),
         };
+        tracing::debug!(%src, "TCP connection accepted");
         if !rate_limiter.check(src.ip()) {
             drop(stream);
             continue;

--- a/src/listener/tls.rs
+++ b/src/listener/tls.rs
@@ -76,15 +76,21 @@ pub async fn serve(
     loop {
         let (stream, src) = match listener.accept().await {
             Ok(pair) => pair,
+            Err(e) if super::is_resource_exhaustion(&e) => {
+                tracing::warn!(%addr, error = %e, "DoT accept() failed: resource exhaustion (EMFILE/ENFILE); backing off");
+                tokio::time::sleep(Duration::from_millis(50)).await;
+                continue;
+            }
             Err(e) if super::is_transient_accept_error(&e) => {
-                tracing::warn!(%addr, error = %e, "Transient accept() error; continuing");
-                if super::is_resource_exhaustion(&e) {
-                    tokio::time::sleep(Duration::from_millis(50)).await;
-                }
+                // Peer aborted before accept(); kernel discards the queued
+                // sockaddr, so source IP is unrecoverable here. Use tcpdump
+                // on the listening interface if you need to identify the client.
+                tracing::debug!(%addr, error = %e, "DoT accept() aborted before peer address available (peer RST mid-handshake)");
                 continue;
             }
             Err(e) => return Err(e.into()),
         };
+        tracing::debug!(%src, "DoT connection accepted");
         if !rate_limiter.check(src.ip()) {
             drop(stream);
             continue;


### PR DESCRIPTION
Closes #84.

## Problem

`rdns::listener::tcp` (and `::tls`) emit a recurring `WARN` for accept() failures with `ECONNABORTED` / `ECONNRESET` / `EPROTO` / `ETIMEDOUT`:

```
WARN rdns::listener::tcp: Transient accept() error; continuing addr=0.0.0.0:53 error=Software caused connection abort (os error 53)
```

These are benign: a peer RST-aborted the TCP handshake before userland `accept()` returned. The listener is healthy and continues. The kernel discards the queued sockaddr, so **there is no peer IP to log** for these — making the WARN doubly bad: noisy *and* unactionable.

Observed on a production AiFw appliance: ~80 events / 12 hours, no functional impact.

## Fix

- `EMFILE` / `ENFILE` (resource exhaustion) → keep `warn!` with backoff. These genuinely warrant operator attention.
- All other transients → `debug!`, with a message that explains why peer IP is unavailable.
- Every successful `accept()` now logs `src=<ip:port>` at `debug!`. Combined with timing of the (now-`debug`) abort events, operators have enough to correlate without tcpdump in most cases.

No behavior change to the accept loop, classifier, or backoff — only log levels and contents.

## Verification

- `cargo check` clean, zero warnings
- `cargo test` — 194/194 pass
- Existing `is_transient_accept_error` / `is_resource_exhaustion` unit tests still cover classification

## Version

`1.17.3` → `1.17.4`