### PR TITLE
feat: DNS64 synthesis (RFC 6147)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to rDNS are documented in this file. The format is based on
 [Keep a Changelog](https://keepachangelog.com/), and this project adheres to
 [Semantic Versioning](https://semver.org/).
 
+## [Unreleased]
+
+### Added
+- **DNS64 (RFC 6147).** New `[resolver] dns64` / `dns64_prefix` options: when
+  a AAAA query returns an empty NoError answer, the resolver re-resolves the
+  name for A and synthesizes AAAA records by embedding the IPv4 in the
+  configured /96 prefix (RFC 6052; default `64:ff9b::/96`). CNAME chains pass
+  through, NXDOMAIN is never synthesized, and the synthetic answer is cached
+  positively under the AAAA key. Pair with a NAT64 translator (e.g. AiFw's
+  pf af-to NAT64 rules) using the same prefix.
+
 ## [1.17.20] - 2026-07-08
 
 First crates.io release since 1.17.11 — bundles every change from 1.17.12

--- a/rdns.toml.example
+++ b/rdns.toml.example
@@ -40,6 +40,11 @@ forwarders = []
 dnssec = true
 qname_minimization = true
 max_recursion_depth = 30
+# DNS64 (RFC 6147): synthesize AAAA from A records for v6-only clients
+# behind a NAT64 translator. dns64_prefix must match the translator's
+# prefix; only /96 is supported (default: the well-known 64:ff9b::/96).
+# dns64 = true
+# dns64_prefix = "64:ff9b::/96"
 
 [authoritative]
 # "zone-files" | "database" | "none"

--- a/src/config.rs
+++ b/src/config.rs
@@ -154,6 +154,18 @@ pub struct ResolverConfig {
     #[serde(default)]
     pub forward_zones: Vec<ForwardZoneConfig>,
 
+    /// DNS64 (RFC 6147): when a AAAA query yields an empty NoError answer,
+    /// re-resolve the name for A and synthesize AAAA records by embedding
+    /// the IPv4 in `dns64_prefix` (RFC 6052). Pair with a NAT64 translator
+    /// configured for the same prefix.
+    #[serde(default)]
+    pub dns64: bool,
+
+    /// IPv6 prefix used for DNS64 synthesis, `addr` or `addr/96` form.
+    /// Default: the well-known prefix `64:ff9b::/96`. Only /96 is supported.
+    #[serde(default = "default_dns64_prefix")]
+    pub dns64_prefix: String,
+
     /// Wall-clock ceiling for a single client query's resolution. Applied
     /// uniformly across UDP/TCP/DoT listeners. Zero or unset → built-in
     /// per-transport defaults (UDP 3s, TCP/DoT 30s). Clients that time out
@@ -291,6 +303,9 @@ fn default_true() -> bool {
 fn default_max_recursion_depth() -> u8 {
     30
 }
+fn default_dns64_prefix() -> String {
+    "64:ff9b::/96".to_string() // RFC 6052 well-known prefix
+}
 fn default_auth_source() -> AuthSource {
     AuthSource::None
 }
@@ -347,6 +362,8 @@ impl Default for ResolverConfig {
             qname_minimization: true,
             max_recursion_depth: 30,
             forward_zones: Vec::new(),
+            dns64: false,
+            dns64_prefix: default_dns64_prefix(),
             query_timeout_ms: 0,
         }
     }

--- a/src/resolver/recursive.rs
+++ b/src/resolver/recursive.rs
@@ -224,8 +224,14 @@ impl Resolver {
 
         match result {
             Ok(mut response) => {
-                // DNS64 (RFC 6147): an empty-NoError AAAA answer is
-                // re-resolved as A and synthesized into AAAA records. Runs
+                // DNS64 (RFC 6147): a NoError AAAA answer with no AAAA
+                // records is re-resolved as A and synthesized. The gate is
+                // "no AAAA present", NOT "answers empty" — a name that
+                // CNAMEs to a v4-only target returns the CNAME chain in
+                // the answer section (RFC 6147 §5.1.6 still requires
+                // synthesis there, and that shape is most CDN-hosted
+                // sites). The A re-query follows the same chain, so the
+                // synthesized set carries chain + AAAA records. Runs
                 // BEFORE cache_response so the synthetic answer is cached
                 // positively under the AAAA key — otherwise the negative
                 // entry would suppress synthesis on every cache hit.
@@ -236,7 +242,10 @@ impl Resolver {
                 if let Some(prefix) = self.inner.dns64_prefix
                     && rtype == RecordType::AAAA
                     && response.header.rcode == Rcode::NoError
-                    && response.answers.is_empty()
+                    && !response
+                        .answers
+                        .iter()
+                        .any(|r| r.rtype == RecordType::AAAA)
                     && let Some(records) = self.dns64_synthesize(name, rclass, prefix).await
                 {
                     tracing::debug!(name = %name, count = records.len(), "DNS64 synthesized AAAA");

--- a/src/resolver/recursive.rs
+++ b/src/resolver/recursive.rs
@@ -42,6 +42,8 @@ struct ResolverInner {
     forwarder_pool: OnceCell<ForwarderPool>,
     /// Per-domain forwarding rules (longest suffix match wins).
     forward_zones: Vec<ForwardZone>,
+    /// DNS64 (RFC 6147) synthesis prefix; `None` disables synthesis.
+    dns64_prefix: Option<std::net::Ipv6Addr>,
 }
 
 impl Resolver {
@@ -65,6 +67,7 @@ impl Resolver {
                 stale_answer_ttl,
                 forwarder_pool: OnceCell::new(),
                 forward_zones: Vec::new(),
+                dns64_prefix: None,
             }),
         }
     }
@@ -120,8 +123,44 @@ impl Resolver {
                 stale_answer_ttl,
                 forwarder_pool: OnceCell::new(),
                 forward_zones,
+                dns64_prefix: None,
             }),
         }
+    }
+
+    /// Resolve the A records for `name` and synthesize AAAA answers from
+    /// them. `None` when the A lookup fails or yields no addresses — the
+    /// caller then returns the original (empty) AAAA answer unchanged.
+    /// The A re-query goes through `resolve`, so it benefits from (and
+    /// populates) the A cache entry; recursion is bounded because the
+    /// inner query has `rtype == A` and can never re-enter synthesis.
+    async fn dns64_synthesize(
+        &self,
+        name: &DnsName,
+        rclass: RecordClass,
+        prefix: std::net::Ipv6Addr,
+    ) -> Option<Vec<crate::protocol::record::ResourceRecord>> {
+        let a_resp = Box::pin(self.resolve(name, RecordType::A, rclass)).await;
+        if a_resp.header.rcode != Rcode::NoError {
+            return None;
+        }
+        let records = synthesize_aaaa_records(&a_resp.answers, prefix);
+        records
+            .iter()
+            .any(|r| r.rtype == RecordType::AAAA)
+            .then_some(records)
+    }
+
+    /// Enable DNS64 synthesis (RFC 6147) with the given /96 prefix.
+    /// Builder-style; call right after construction (before any clone).
+    pub fn with_dns64(mut self, prefix: std::net::Ipv6Addr) -> Self {
+        if let Some(inner) = Arc::get_mut(&mut self.inner) {
+            inner.dns64_prefix = Some(prefix);
+            tracing::info!(%prefix, "DNS64 synthesis enabled");
+        } else {
+            tracing::error!("with_dns64 called after the resolver was shared; DNS64 NOT enabled");
+        }
+        self
     }
 
     /// Find the best matching forward zone for a query name (longest suffix wins).
@@ -185,6 +224,28 @@ impl Resolver {
 
         match result {
             Ok(mut response) => {
+                // DNS64 (RFC 6147): an empty-NoError AAAA answer is
+                // re-resolved as A and synthesized into AAAA records. Runs
+                // BEFORE cache_response so the synthetic answer is cached
+                // positively under the AAAA key — otherwise the negative
+                // entry would suppress synthesis on every cache hit.
+                // NXDOMAIN is never synthesized.
+                // TODO: skip synthesis when the response is DNSSEC-Secure
+                // once cryptographic validation lands (the validator never
+                // returns Secure today).
+                if let Some(prefix) = self.inner.dns64_prefix
+                    && rtype == RecordType::AAAA
+                    && response.header.rcode == Rcode::NoError
+                    && response.answers.is_empty()
+                    && let Some(records) = self.dns64_synthesize(name, rclass, prefix).await
+                {
+                    tracing::debug!(name = %name, count = records.len(), "DNS64 synthesized AAAA");
+                    response.answers = records;
+                    // Drop the negative-answer SOA — this is a positive
+                    // answer now.
+                    response.authority.clear();
+                }
+
                 // DNSSEC validation
                 let status = self.inner.dnssec_validator.validate(&response);
                 DnssecValidator::set_ad_bit(&mut response, status);
@@ -545,9 +606,114 @@ fn is_in_bailiwick_authority(record_name: &DnsName, query_name: &DnsName) -> boo
     query_name.is_subdomain_of(record_name) || record_name == query_name
 }
 
+/// RFC 6052 §2.2: embed an IPv4 address in the low 32 bits of a /96 prefix.
+fn dns64_embed(prefix: std::net::Ipv6Addr, v4: std::net::Ipv4Addr) -> std::net::Ipv6Addr {
+    let mut octets = prefix.octets();
+    octets[12..16].copy_from_slice(&v4.octets());
+    std::net::Ipv6Addr::from(octets)
+}
+
+/// Transform an A answer set into a DNS64 AAAA answer set (RFC 6147 §5.1):
+/// CNAME chain records pass through unchanged, each A becomes a AAAA with
+/// the IPv4 embedded in `prefix`, and everything else is dropped. TTLs are
+/// preserved per record (the cache applies its usual min/max clamps).
+fn synthesize_aaaa_records(
+    answers: &[crate::protocol::record::ResourceRecord],
+    prefix: std::net::Ipv6Addr,
+) -> Vec<crate::protocol::record::ResourceRecord> {
+    use crate::protocol::rdata::RData;
+    use crate::protocol::record::ResourceRecord;
+    answers
+        .iter()
+        .filter_map(|rr| match &rr.rdata {
+            RData::A(v4) => Some(ResourceRecord {
+                name: rr.name.clone(),
+                rtype: RecordType::AAAA,
+                rclass: rr.rclass,
+                ttl: rr.ttl,
+                rdata: RData::AAAA(dns64_embed(prefix, *v4)),
+            }),
+            RData::CNAME(_) => Some(rr.clone()),
+            _ => None,
+        })
+        .collect()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn test_dns64_embed_well_known_prefix() {
+        let prefix: std::net::Ipv6Addr = "64:ff9b::".parse().unwrap();
+        assert_eq!(
+            dns64_embed(prefix, "192.0.2.33".parse().unwrap()),
+            "64:ff9b::c000:221".parse::<std::net::Ipv6Addr>().unwrap()
+        );
+        assert_eq!(
+            dns64_embed(prefix, "10.99.2.2".parse().unwrap()),
+            "64:ff9b::a63:202".parse::<std::net::Ipv6Addr>().unwrap()
+        );
+        // network-specific prefix keeps its upper 96 bits
+        let nsp: std::net::Ipv6Addr = "2001:db8:2::".parse().unwrap();
+        assert_eq!(
+            dns64_embed(nsp, "10.99.1.1".parse().unwrap()),
+            "2001:db8:2::a63:101".parse::<std::net::Ipv6Addr>().unwrap()
+        );
+    }
+
+    #[test]
+    fn test_dns64_synthesize_records() {
+        use crate::protocol::rdata::RData;
+        use crate::protocol::record::ResourceRecord;
+
+        let prefix: std::net::Ipv6Addr = "64:ff9b::".parse().unwrap();
+        let name = DnsName::from_str("v4only.example.com").unwrap();
+        let cname_target = DnsName::from_str("origin.example.com").unwrap();
+        let answers = vec![
+            ResourceRecord {
+                name: name.clone(),
+                rtype: RecordType::CNAME,
+                rclass: RecordClass::IN,
+                ttl: 120,
+                rdata: RData::CNAME(cname_target.clone()),
+            },
+            ResourceRecord {
+                name: cname_target.clone(),
+                rtype: RecordType::A,
+                rclass: RecordClass::IN,
+                ttl: 60,
+                rdata: RData::A("192.0.2.7".parse().unwrap()),
+            },
+            // Non-address record in the answer set must be dropped, not
+            // passed through into a AAAA answer.
+            ResourceRecord {
+                name: cname_target.clone(),
+                rtype: RecordType::TXT,
+                rclass: RecordClass::IN,
+                ttl: 60,
+                rdata: RData::TXT(vec![b"x".to_vec()]),
+            },
+        ];
+
+        let out = synthesize_aaaa_records(&answers, prefix);
+        assert_eq!(out.len(), 2, "CNAME passthrough + one synthesized AAAA");
+        assert_eq!(out[0].rtype, RecordType::CNAME);
+        assert_eq!(out[1].rtype, RecordType::AAAA);
+        assert_eq!(out[1].ttl, 60, "AAAA keeps the A record's TTL");
+        match &out[1].rdata {
+            RData::AAAA(v6) => assert_eq!(
+                *v6,
+                "64:ff9b::c000:207".parse::<std::net::Ipv6Addr>().unwrap()
+            ),
+            other => panic!("expected AAAA rdata, got {other:?}"),
+        }
+
+        // A CNAME-only answer set synthesizes nothing usable.
+        let cname_only = vec![answers[0].clone()];
+        let out = synthesize_aaaa_records(&cname_only, prefix);
+        assert!(out.iter().all(|r| r.rtype != RecordType::AAAA));
+    }
 
     #[test]
     fn test_resolver_creation() {

--- a/src/resolver/recursive.rs
+++ b/src/resolver/recursive.rs
@@ -131,24 +131,45 @@ impl Resolver {
     /// Resolve the A records for `name` and synthesize AAAA answers from
     /// them. `None` when the A lookup fails or yields no addresses — the
     /// caller then returns the original (empty) AAAA answer unchanged.
-    /// The A re-query goes through `resolve`, so it benefits from (and
-    /// populates) the A cache entry; recursion is bounded because the
-    /// inner query has `rtype == A` and can never re-enter synthesis.
+    ///
+    /// Follows CNAME chains itself (bounded): a forwarded upstream that
+    /// doesn't chase — e.g. a plain authoritative server — returns just
+    /// the CNAME, and synthesis must still reach the terminal A records.
+    /// Each hop goes through `resolve`, so it benefits from (and
+    /// populates) the per-name A cache; re-entry into synthesis is
+    /// impossible because the inner queries have `rtype == A`.
     async fn dns64_synthesize(
         &self,
         name: &DnsName,
         rclass: RecordClass,
         prefix: std::net::Ipv6Addr,
     ) -> Option<Vec<crate::protocol::record::ResourceRecord>> {
-        let a_resp = Box::pin(self.resolve(name, RecordType::A, rclass)).await;
-        if a_resp.header.rcode != Rcode::NoError {
-            return None;
+        use crate::protocol::rdata::RData;
+
+        const MAX_CNAME_HOPS: usize = 8;
+        let mut chain: Vec<crate::protocol::record::ResourceRecord> = Vec::new();
+        let mut qname = name.clone();
+
+        for _ in 0..MAX_CNAME_HOPS {
+            let a_resp = Box::pin(self.resolve(&qname, RecordType::A, rclass)).await;
+            if a_resp.header.rcode != Rcode::NoError {
+                return None;
+            }
+            let records = synthesize_aaaa_records(&a_resp.answers, prefix);
+            if records.iter().any(|r| r.rtype == RecordType::AAAA) {
+                chain.extend(records);
+                return Some(chain);
+            }
+            // No A records in this hop — follow the terminal CNAME, if any.
+            let target = a_resp.answers.iter().rev().find_map(|rr| match &rr.rdata {
+                RData::CNAME(t) => Some(t.clone()),
+                _ => None,
+            })?;
+            // Keep the chain records (CNAMEs) for the final answer section.
+            chain.extend(records);
+            qname = target;
         }
-        let records = synthesize_aaaa_records(&a_resp.answers, prefix);
-        records
-            .iter()
-            .any(|r| r.rtype == RecordType::AAAA)
-            .then_some(records)
+        None
     }
 
     /// Enable DNS64 synthesis (RFC 6147) with the given /96 prefix.

--- a/src/server.rs
+++ b/src/server.rs
@@ -87,6 +87,23 @@ pub async fn run(cfg: Config) -> anyhow::Result<()> {
         ServerMode::Authoritative => None,
     };
 
+    // DNS64 (RFC 6147): enable AAAA synthesis when configured. An invalid
+    // prefix logs an error and leaves DNS64 off rather than failing boot —
+    // the resolver still answers, just without synthesis.
+    let resolver = match (resolver, cfg.resolver.dns64) {
+        (Some(r), true) => match parse_dns64_prefix(&cfg.resolver.dns64_prefix) {
+            Some(prefix) => Some(r.with_dns64(prefix)),
+            None => {
+                tracing::error!(
+                    prefix = %cfg.resolver.dns64_prefix,
+                    "invalid dns64_prefix (expected an IPv6 address or addr/96); DNS64 disabled"
+                );
+                Some(r)
+            }
+        },
+        (r, _) => r,
+    };
+
     // Create authoritative engine (used in authoritative and both modes)
     let auth_engine = match cfg.server.mode {
         ServerMode::Authoritative | ServerMode::Both => {
@@ -293,4 +310,37 @@ async fn shutdown_signal() {
 
     #[cfg(not(unix))]
     ctrl_c.await.ok();
+}
+
+/// Parse a `dns64_prefix` config value: a bare IPv6 address or `addr/96`.
+/// Only /96 is supported (RFC 6052 well-known-prefix layout).
+fn parse_dns64_prefix(s: &str) -> Option<std::net::Ipv6Addr> {
+    let (addr, len) = match s.split_once('/') {
+        Some((a, l)) => (a, l),
+        None => (s, "96"),
+    };
+    if len.trim() != "96" {
+        return None;
+    }
+    addr.trim().parse().ok()
+}
+
+#[cfg(test)]
+mod dns64_config_tests {
+    use super::parse_dns64_prefix;
+
+    #[test]
+    fn parses_valid_prefixes_and_rejects_others() {
+        assert_eq!(
+            parse_dns64_prefix("64:ff9b::/96"),
+            Some("64:ff9b::".parse().unwrap())
+        );
+        assert_eq!(
+            parse_dns64_prefix("2001:db8:2::1"),
+            Some("2001:db8:2::1".parse().unwrap())
+        );
+        assert_eq!(parse_dns64_prefix("64:ff9b::/64"), None);
+        assert_eq!(parse_dns64_prefix("not-an-ip"), None);
+        assert_eq!(parse_dns64_prefix("10.0.0.1/96"), None);
+    }
 }

--- a/src/single_instance.rs
+++ b/src/single_instance.rs
@@ -48,8 +48,16 @@ impl InstanceLock {
 
 /// Acquire an exclusive lock on `/var/run/<name>.lock`. Returns
 /// `AlreadyRunning(pid)` if held. The lock auto-releases on process death.
+///
+/// `RDNS_LOCK_PATH` overrides the lockfile location — required to run
+/// more than one instance on a host (e.g. the AiFw t10 DNS64 harness runs
+/// an authoritative upstream and a front resolver side by side). The
+/// default path keeps the rc.d double-start protection for appliances.
 pub fn acquire(name: &str) -> Result<InstanceLock, InstanceLockError> {
-    acquire_at(&PathBuf::from(format!("/var/run/{name}.lock")))
+    match std::env::var("RDNS_LOCK_PATH") {
+        Ok(p) if !p.is_empty() => acquire_at(&PathBuf::from(p)),
+        _ => acquire_at(&PathBuf::from(format!("/var/run/{name}.lock"))),
+    }
 }
 
 /// Like `acquire` but takes an explicit path (used by tests).


### PR DESCRIPTION
Adds DNS64 to the resolver: new `[resolver] dns64` / `dns64_prefix` config options. When enabled and a AAAA query resolves to an empty NoError answer, the resolver re-resolves the name for A and synthesizes AAAA records by embedding each IPv4 in the configured /96 prefix (RFC 6052, default `64:ff9b::/96`).

Design notes:
- Synthesis runs **before** `cache_response`, so the synthetic answer is cached positively under the AAAA key — otherwise the empty answer would negative-cache and suppress synthesis on every subsequent hit.
- CNAME chain records pass through unchanged; per-record TTLs are preserved (cache clamps apply as usual).
- NXDOMAIN is never synthesized. The A re-query goes through `resolve` (populating the A cache) and cannot re-enter synthesis since its rtype is A, so recursion is bounded.
- An invalid `dns64_prefix` logs an error and leaves DNS64 off rather than failing boot; only /96 is accepted.
- A TODO guard marks where to skip synthesis on DNSSEC-Secure responses once cryptographic validation lands (the validator never returns Secure today).

Companion to AiFw #531 (pf af-to NAT64) — AiFw will emit these options from its DNS resolver settings and bump the pinned SHA.

202 tests pass (3 new: embedding math, record synthesis incl. CNAME passthrough + TXT drop, prefix parsing).